### PR TITLE
Custom code server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,28 @@ jobs:
           path: ~/repo
       - setup_remote_docker
       - run:
-          name: Build and push Postgres Image
+          name: Build and push postgres image
+          command: |
+            docker build -f Dockerfile -t $IMAGE_NAME:latest .
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
+            docker push $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:$IMAGE_TAG
+  
+  build_code_server:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    environment:
+      IMAGE_NAME: shaungc/code-server
+      # change this and tf microservice module `app_container_image_tag` to pick up changes and use it in deployment
+      IMAGE_TAG: 3.9.3
+    working_directory: ~/repo/code-server
+    steps:
+      - checkout:
+          path: ~/repo
+      - setup_remote_docker
+      - run:
+          name: Build and push code-server image
           command: |
             docker build -f Dockerfile -t $IMAGE_NAME:latest .
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
@@ -137,11 +158,17 @@ workflows:
               branches:
                 only:
                   - release
+      - build_code_server:
+          filters:
+              branches:
+                only:
+                  - release
       - exec_terraform:
           filters:
               branches:
                 only:
                   - release
                   - destroy-release
-          # requires:
-          #   - build
+          requires:
+            - build_postgres
+            - build_code_server

--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -10,20 +10,20 @@ ENV TERRAFORM_VERSION=0.12.18
 ENV DOCTL_VERSION=1.36.0
 
 # setup git
-RUN git config --global user.name ${USER_FULL_NAME} && \
-    git config --global user.email ${USER_EMAIL}
+# RUN git config --global user.name ${USER_FULL_NAME} && \
+    # git config --global user.email ${USER_EMAIL}
 
 # install zsh & autocomplete
-echo -e "INFO: Installing Oh my Zsh framework..." && \
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+RUN echo -e "INFO: Installing Oh my Zsh framework..." && \
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 # zsh syntax-highlighting - let shell commands keywords be recognized and displayed in green, etc
 # https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/INSTALL.md
-git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 
 # zsh autosuggestions (grayed-out words hinting you)
 # https://github.com/zsh-users/zsh-autosuggestions
-git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
 
 # TODO: add zsh plugin
 

--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -1,0 +1,11 @@
+FROM codercom/code-server:3.9.3
+
+# TODO: 
+
+# TODO: require secrets injected in microservice
+
+# install zsh & autocomplete
+RUN git config --global user.name ${USER_FULL_NAME} && \
+    git config --global user.email ${USER_EMAIL}
+
+# install dev tools (doctl, terraform, kubectl)

--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -1,11 +1,47 @@
 FROM codercom/code-server:3.9.3
 
-# TODO: 
+# TODO: run docker in pod / or build on circleCI|GithubAction
 
 # TODO: require secrets injected in microservice
+ENV USER_FULL_NAME=
+ENV USER_EMAIL=
 
-# install zsh & autocomplete
+ENV TERRAFORM_VERSION=0.12.18
+ENV DOCTL_VERSION=1.36.0
+
+# setup git
 RUN git config --global user.name ${USER_FULL_NAME} && \
     git config --global user.email ${USER_EMAIL}
 
+# install zsh & autocomplete
+echo -e "INFO: Installing Oh my Zsh framework..." && \
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# zsh syntax-highlighting - let shell commands keywords be recognized and displayed in green, etc
+# https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/INSTALL.md
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+
+# zsh autosuggestions (grayed-out words hinting you)
+# https://github.com/zsh-users/zsh-autosuggestions
+git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+
+# TODO: add zsh plugin
+
+# TODO: set vscode default shell to zsh
+
 # install dev tools (doctl, terraform, kubectl)
+RUN sudo apt-get update -y && sudo apt-get install unzip
+
+RUN cd /tmp && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kubectl && \
+    sudo mv ./kubectl /bin/kubectl && \
+    sudo chmod +x /bin/kubectl
+
+RUN cd /tmp && curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin
+
+RUN cd /tmp && curl -OL https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz && \
+    tar xf doctl-${DOCTL_VERSION}-linux-amd64.tar.gz --directory /usr/bin
+
+RUN rm -rf /tmp/* && \
+    rm -rf /var/cache/apk/* && \
+    rm -rf /var/tmp/*

--- a/terraform/code-server.tf
+++ b/terraform/code-server.tf
@@ -12,7 +12,7 @@ module "code_server" {
   app_exposed_port    = 8003
   app_deployed_domain = "code-server.shaungc.com"
 
-  app_container_image     = "codercom/code-server"
+  app_container_image     = "shaungc/code-server"
   app_container_image_tag = "3.9.3"
 
   app_secret_name_list = [


### PR DESCRIPTION
For installing our regular dev tools.

Note that only things that relates to system files need to do this. Because of persistent storage, other settings / files should be already there. 

Also make sure we don't commit credentials into docker image, and we should use a entry point script instead. However, code-server entry point script is not clear yet and we might have to inspect how to extend beyond by our self.