### PR TITLE
Remove uneeded kubeconfig generation to support dynamic (randomized) cluster name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,7 @@ jobs:
           command: |
             kubectl version --client
             DIGITALOCEAN_ACCESS_TOKEN=$TF_VAR_do_token doctl auth init
-            mkdir -p ~/.kube
-            doctl k8s cluster kubeconfig show project-shaungc-digitalocean-cluster > ~/.kube/config || true
-            kubectl get all --all-namespaces || true
+            doctl k8s cluster list
             docker -v
       - run:
           name: Initiate Terraform Against Cluster

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -85,9 +85,6 @@ provider "kubernetes" {
   # all k8 provider versions: https://github.com/terraform-providers/terraform-provider-kubernetes/blob/master/CHANGELOG.md
   version = "1.13.3"
 
-  # config_path = "./${local_file.kubeconfig.filename}"
-  # config_path = "./kubeconfig.yaml"
-
   host = digitalocean_kubernetes_cluster.project_digitalocean_cluster.endpoint
 
   load_config_file = false

--- a/terraform/prometheus.tf
+++ b/terraform/prometheus.tf
@@ -67,9 +67,6 @@ resource "helm_release" "prometheus_stack" {
     #
     # Way to debug such error: https://github.com/helm/helm/issues/5100#issuecomment-533787541
     kubernetes_cluster_role_binding.tiller,
-
-    # script `my-kubectl.sh` requires kubeconfig.yaml
-    local_file.kubeconfig
   ]
 }
 


### PR DESCRIPTION
These are not adding anything new; but rather trim any needed kubeconfig gen, which often time uses hard-coded cluster name.

Now we use randomized hash in cluster name, so these needs to be removed, or find ways to propagate random value.

The random value is fully managed by terraform and stored in tfstate, so that it only gets generated the 1st time.